### PR TITLE
feat: add tab scheduling with options page and improve tab cycling

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,8 @@
+// Tab Cycling
 let intervalId = null;
 let intervalSeconds = 15; // Default value
+let isCycling = false;
+let cyclingPaused = false;
 
 chrome.storage.local.set({ intervalSeconds });
 
@@ -35,6 +38,7 @@ function startCycling() {
     if (!intervalId) {
         setIntervalId(cycleTabs, intervalSeconds);
         console.log(`Started cycling every ${intervalSeconds} seconds.`);
+        isCycling = true;
     }
 }
 
@@ -44,6 +48,7 @@ function stopCycling() {
         clearInterval(intervalId);
         intervalId = null;
         console.log("Stopped cycling.");
+        isCycling = false;
     }
 }
 
@@ -57,9 +62,141 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
     if (message.action === "setInterval") {
         updateInterval(message.value);
-        stopCycling();
-        startCycling();
+        if (isCycling) {
+            stopCycling();
+            startCycling();
+        }
         sendResponse({ success: true });
       }
     sendResponse({ success: true });
+});
+
+// Tab Scheduling
+function padTime(num) {
+    return num.toString().padStart(2, '0');
+  }
+  
+function scheduleTabs(alarm) {
+    const now = new Date();
+    const currentDay = now.getDay(); // 0 (Sun) to 6 (Sat)
+    const currentTime = `${padTime(now.getHours())}:${padTime(now.getMinutes())}`;
+    
+    const match = alarm.name.match(/^tab-(\d+)-(\d)$/);
+    if (!match) return;
+
+    const index = parseInt(match[1]);
+
+    chrome.storage.local.get("schedules", (res) => {
+        const entry = res.schedules?.[index];
+
+            if (entry) {
+                // Pause cycling
+                if (isCycling) {
+                    stopCycling();
+                    cyclingPaused = true;
+                }
+                if (
+                    entry.enabled &&
+                    entry.days.includes(currentDay) &&
+                    entry.time === currentTime
+                ) {
+
+                    const [hour, minute] = entry.time.split(":").map(Number);
+                    chrome.tabs.create({ url: entry.url, active: entry.focus || false}, (tab) => {
+                        if (entry.autoclose > 0) {
+                            const alarmName = `autoclose-${tab.id}`;
+                            const alarmDate = new Date(now);
+                            alarmDate.setDate(now.getDate());
+                            alarmDate.setHours(hour, minute, entry.autoclose, 0);
+                            chrome.alarms.create(alarmName, {
+                                when: alarmDate.getTime()
+                            });
+                            if (entry.autodisable) {
+                                const disableAlarmName = `autodisable-${index}`;
+                                chrome.alarms.create(disableAlarmName, {
+                                    when: alarmDate.getTime()
+                                });
+                            }
+                        }
+                    });
+                }
+        }});    
+    }
+        
+function setupAlarms() {
+    chrome.alarms.clearAll(() => {
+    chrome.storage.local.get("schedules", (res) => {
+        const schedules = res.schedules || [];
+
+        schedules.forEach((entry, index) => {
+            if (!entry.enabled || !entry.days?.length || !entry.time) return;
+
+            const now = new Date();
+            const [hour, minute] = entry.time.split(":").map(Number);
+
+            for (let i = 0; i < 7; i++) {
+                const alarmDay = (now.getDay() + i) % 7;
+                if (entry.days.includes(alarmDay)) {
+                    const alarmDate = new Date(now);
+                    alarmDate.setDate(now.getDate() + i);
+                    alarmDate.setHours(hour, minute, 0, 0);
+
+                    if (alarmDate > now) {
+                        chrome.alarms.create(`tab-${index}-${alarmDay}`, {
+                            when: alarmDate.getTime()
+                        });
+                        break; // Only schedule the next closest time
+                    }
+                }
+            }
+            });
+        });
+    });
+}
+
+chrome.runtime.onInstalled.addListener(setupAlarms);
+chrome.runtime.onStartup.addListener(setupAlarms);
+chrome.storage.onChanged.addListener(setupAlarms);
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+    scheduleTabs(alarm)
+    console.log(`[autoclose] Alarm triggered: ${alarm.name}`);
+    const match = alarm.name.match(/^autoclose-(\d+)$/);
+    if (match) {
+        const tabId = parseInt(match[1]);
+        chrome.tabs.remove(tabId).then(() => {
+            console.log(`[autoclose] Removed tab ${tabId}`);
+        }).catch((err) => {
+            console.warn(`[autoclose] Failed to remove tab ${tabId}:`, err);
+        });
+
+        if (cyclingPaused) {
+            console.log("[autoclose] Resuming cycling...");
+            startCycling();
+            cyclingPaused = false;
+        }
+    }
+    const disableMatch = alarm.name.match(/^autodisable-(\d+)$/);
+    if (disableMatch) {
+        const index = parseInt(disableMatch[1]);
+        chrome.storage.local.get("schedules", (res) => {
+            const schedules = res.schedules || [];
+            if (schedules[index]) {
+                schedules[index].enabled = false;
+                chrome.storage.local.set({ schedules }, () => {
+                    console.log(`[autodisable] Disabled schedule at index ${index}`);
+                });
+            }
+        });
+    }
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+    if (msg.action === "previewNow") {
+        chrome.storage.local.get("schedules", (res) => {
+            res.schedules?.forEach((schedule) => {
+                chrome.tabs.create({ url: schedule.url });
+            });
+        });
+    }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,10 @@
 {
     "manifest_version": 3,
     "name": "TabCycle",
-    "version": "1.1.0",
-    "description": "Cycles through open tabs at a set time interval.",
-    "permissions": ["storage"],
+    "version": "2.0.0",
+    "description": "Cycles through open tabs at a set time interval, and schedules tabs to open at specific dates/times, with per-tab scheduling.",
+    "permissions": ["storage", "alarms", "tabs", "scripting"],
+    "host_permissions": ["<all_urls>"],
     "background": {
         "service_worker": "background.js"
     },
@@ -16,12 +17,17 @@
             "128": "icons/icon128.png"
         }
     },
+    "options_ui": {
+        "page": "options.html",
+        "open_in_tab": true
+    },
     "web_accessible_resources": [
         {
         "resources": ["styles.css"],
         "matches": ["<all_urls>"]
         }
     ],
+    "options_page": "options.html",
     "icons": {
         "16": "icons/icon16.png",
         "48": "icons/icon48.png",

--- a/options.css
+++ b/options.css
@@ -1,0 +1,186 @@
+body {
+    font-family: sans-serif;
+    padding: 1em 2em;
+    max-width: 1000px;
+    margin: auto;
+    background: #f9f9f9;
+}
+
+h1 {
+    font-size: 2em;
+    margin-bottom: 1em;
+    text-align: center;
+    opacity: 1;
+}
+h2 {
+    font-size: 1.5em;
+    margin-bottom: 1em;
+    text-align: center;
+    opacity: 1;
+}
+.schedule-entry {
+    background: #fff;
+    border: 1px solid #ddd;
+    padding: 1em;
+    margin-bottom: 1em;
+    border-radius: 8px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+    display: grid;
+    grid-template-columns: 2fr 1fr auto auto;
+    gap: 1em;
+    align-items: center;
+}
+
+.schedule-entry input[type="url"] {
+    width: 100%;
+}
+
+.schedule-entry input[type="time"],
+.schedule-entry input[type="number"] {
+    width: 100%;
+}
+
+.schedule-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+}
+
+button {
+    padding: 0.4em 0.8em;
+    border: none;
+    background: #007acc;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #005fa3;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 42px;
+    height: 22px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-color: #ccc;
+    transition: 0.3s;
+    border-radius: 22px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 16px;
+    width: 16px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: 0.3s;
+    border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+    background-color: #007acc;
+}
+
+.switch input:checked + .slider:before {
+    transform: translateX(20px);
+}
+
+.autofocus {
+    font-size: 0.85em;
+    margin-top: 0.5em;
+}
+
+table {
+  width: 105%;
+  border-collapse: collapse;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  margin-bottom: 1em;
+  opacity: 1;
+}
+
+th, td {
+    padding: 8px 10px;
+    text-align: left;
+    border: 1px solid #ddd; /* ✅ Adds lines between columns and rows */
+  }
+
+th {
+  background-color: #003366; /* ✅ Dark blue */
+  color: white;
+  font-weight: 600;
+}
+
+tbody tr:nth-child(even) {
+    background-color: #f2f2f2; /* ✅ Alternating row color */
+}
+  
+tbody tr:hover {
+    background-color: #e0eaff; /* ✅ Hover highlight effect */
+}
+
+input[type="url"], input[type="text"], input[type="time"], input[type="number"] {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.days {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3em;
+    margin-top: 0.4em;
+}
+
+.days label {
+  background: #eee;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.8em;
+}
+
+.toast {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    background-color: #4CAF50;
+    color: white;
+    padding: 12px 20px;
+    border-radius: 8px;
+    font-weight: bold;
+    font-size: 1.5em; /* or use px like 24px */
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+    pointer-events: none;
+    z-index: 9999;
+  }
+.toast.show {
+    opacity: 1;
+}
+
+@keyframes fadeSlideUp {
+    0% {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Scheduled Tab Options</title>
+  <link rel="stylesheet" href="options.css" />
+</head>
+<body>
+  <div id="toast" class="toast">Saved!</div>
+  <h1>TabCycle Options</h1>
+  <h2>Current Scheduled Tab Configurations</h2>
+  <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
+    <button id="save-all">💾 Save</button>
+    <span style="font-size: 1em; color: black;">Changes are saved automatically.</span>
+  </div>
+  
+  <table>
+    <thead>
+      <tr>
+        <th>Active</th>
+        <th>Name</th>
+        <th>URL</th>
+        <th>Time & Days</th>
+        <th>Auto-Close (sec)</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+      <tbody id="schedule-body">
+    </tbody>
+  </table>
+  
+  <button id="add-schedule">➕ Add New Tab</button>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,248 @@
+const scheduleList = document.getElementById("schedule-list");
+const addButton = document.getElementById("add-schedule");
+const saveAllButton = document.getElementById("save-all");
+
+const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function showSavedMessage() {
+    const toast = document.getElementById("toast");
+    toast.classList.add("show");
+
+    clearTimeout(showSavedMessage.timeout);
+    showSavedMessage.timeout = setTimeout(() => {
+        toast.classList.remove("show");
+    }, 1500); // 1.5 seconds visible before fade out
+}
+
+
+function debounce(func, delay) {
+    let timeoutId;
+    return (...args) => {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => func(...args), delay);
+    };
+}
+
+function createScheduleEntry(data = {
+    enabled: true,
+    name: "",
+    url: "",
+    time: "08:00",
+    days: [],
+    autoclose: 0,
+    autodisable: false,
+    focus: false
+    }, index = null) {
+    const row = document.createElement("tr");
+
+    // Active toggle
+    const activeCell = document.createElement("td");
+    const toggleEnabled = document.createElement("label");
+    toggleEnabled.className = "switch";
+    toggleEnabled.innerHTML = `
+        <input type="checkbox" ${data.enabled ? "checked" : ""}>
+        <span class="slider"></span>
+    `;
+    activeCell.appendChild(toggleEnabled);
+    row.appendChild(activeCell);
+
+    // Name
+    const nameCell = document.createElement("td");
+    const nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.placeholder = "Tab Name";
+    nameInput.value = data.name || "";
+    nameCell.appendChild(nameInput);
+    row.appendChild(nameCell);
+
+    // URL
+    const urlCell = document.createElement("td");
+    const urlInput = document.createElement("input");
+    urlInput.type = "url";
+    urlInput.placeholder = "https://example.com";
+    urlInput.value = data.url;
+    urlCell.appendChild(urlInput);
+    row.appendChild(urlCell);
+
+    // Time & Details
+    const timeCell = document.createElement("td");
+
+    const timeInput = document.createElement("input");
+    timeInput.type = "time";
+    timeInput.value = data.time;
+    timeInput.style.display = "block";
+
+    const daysDiv = document.createElement("div");
+    daysDiv.className = "days";
+    weekdays.forEach((day, i) => {
+        const label = document.createElement("label");
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.checked = data.days.includes(i);
+        checkbox.dataset.index = i;
+        label.appendChild(checkbox);
+        label.append(" " + day);
+        daysDiv.appendChild(label);
+    });
+
+    const autofocusLabel = document.createElement("label");
+    const autofocusInput = document.createElement("input");
+    autofocusInput.type = "checkbox";
+    autofocusInput.checked = data.focus;
+    autofocusLabel.appendChild(autofocusInput);
+    autofocusLabel.append(" Autofocus");
+
+    const autodisableLabel = document.createElement("label");
+    const autodisableInput = document.createElement("input");
+    autodisableInput.type = "checkbox";
+    autodisableInput.checked = data.autodisable;
+    autodisableLabel.appendChild(autodisableInput);
+    autodisableLabel.append(" Autodisable");
+
+    timeCell.appendChild(timeInput);
+    timeCell.appendChild(daysDiv);
+    timeCell.appendChild(autofocusLabel);
+    timeCell.appendChild(autodisableLabel);
+
+    row.appendChild(timeCell);
+
+    // Auto-Close
+    const autocloseCell = document.createElement("td");
+    const autocloseInput = document.createElement("input");
+    autocloseInput.type = "number";
+    autocloseInput.placeholder = "Seconds";
+    autocloseInput.value = data.autoclose || 0;
+    autocloseInput.style.width = "50%";
+    autocloseCell.appendChild(autocloseInput);
+    autocloseCell.style.width = "90px";
+
+    row.appendChild(autocloseCell);
+
+    const save = (index, updatedEntry) => {
+        chrome.storage.local.get("schedules", (res) => {
+            const schedules = res.schedules || [];
+            if (index !== null) {
+                schedules[index] = updatedEntry; // Update existing schedule
+            } else {
+                schedules.push(updatedEntry); // Add new schedule
+            }
+            chrome.storage.local.set({ schedules }, () => {
+                showSavedMessage();
+            });
+        });
+    }
+    
+    const debouncedSave = debounce((index, updatedEntry) => {
+        chrome.storage.local.get("schedules", (res) => {
+            const schedules = res.schedules || [];
+    
+            // Defensive check
+            if (index != null && index < schedules.length) {
+                schedules[index] = updatedEntry;
+            }
+    
+            chrome.storage.local.set({ schedules }, () => {
+                showSavedMessage();
+            });
+        });
+    }, 1000);
+    
+    // Event listeners for automatic saving
+    const updateSchedule = () => {
+        const days = [...daysDiv.querySelectorAll("input:checked")].map(cb => parseInt(cb.dataset.index));
+        const newData = {
+            url: urlInput.value,
+            name: nameInput.value,
+            time: timeInput.value,
+            days,
+            autoclose: parseInt(autocloseInput.value) || 0,
+            enabled: toggleEnabled.querySelector("input").checked,
+            focus: autofocusInput.checked,
+            autodisable: autodisableInput.checked
+        };
+        
+        debouncedSave(index, newData);
+    };
+
+    // Add event listeners to inputs
+    nameInput.addEventListener("input", updateSchedule);
+    urlInput.addEventListener("input", updateSchedule);
+    timeInput.addEventListener("input", updateSchedule);
+    autocloseInput.addEventListener("input", updateSchedule);
+    autofocusInput.addEventListener("change", updateSchedule);
+    autodisableInput.addEventListener("change", updateSchedule);
+    daysDiv.querySelectorAll("input").forEach(checkbox => {
+        checkbox.addEventListener("change", updateSchedule);
+    });
+    toggleEnabled.querySelector("input").addEventListener("change", updateSchedule);
+
+    // Action buttons (delete)
+    const actionCell = document.createElement("td");
+    const deleteBtn = document.createElement("button");
+    deleteBtn.textContent = "X Delete";
+    deleteBtn.title = "Delete";
+
+    deleteBtn.onclick = () => {
+        chrome.storage.local.get("schedules", (res) => {
+        const schedules = res.schedules || [];
+        if (index !== null) {
+            schedules.splice(index, 1);
+            chrome.storage.local.set({ schedules }, () => location.reload());
+        }
+        });
+    };
+
+    actionCell.appendChild(deleteBtn);
+    row.appendChild(actionCell);
+
+    document.querySelector("#schedule-body").appendChild(row);
+}
+
+chrome.storage.local.get("schedules", (res) => {
+    const schedules = res.schedules || [];
+    schedules.forEach((sched, i) => createScheduleEntry(sched, i));
+});
+
+addButton.onclick = () => {
+    chrome.storage.local.get("schedules", (res) => {
+        const schedules = res.schedules || [];
+        schedules.push({
+            enabled: true,
+            name: "",
+            url: "",
+            time: "08:00",
+            days: [],
+            autoclose: 0,
+            autodisable: false,
+            focus: false
+        });
+        chrome.storage.local.set({ schedules }, () => {
+            location.reload(); // Ensures the new entry is indexed properly
+        });
+    });
+};
+
+saveAllButton.onclick = () => {
+    const rows = document.querySelectorAll("#schedule-body tr");
+    const updatedSchedules = [];
+
+    rows.forEach(row => {
+        const enabled = row.querySelector("td:nth-child(1) input").checked;
+        const name = row.querySelector("td:nth-child(2) input").value;
+        const url = row.querySelector("td:nth-child(3) input").value;
+        const time = row.querySelector("td:nth-child(4) input[type='time']").value;
+        const fourthTd = row.querySelector("td:nth-child(4)");
+        const checkboxes = fourthTd.querySelectorAll("input[type='checkbox']");
+        const focus = checkboxes[checkboxes.length - 2].checked;
+        const autodisable = checkboxes[checkboxes.length - 1].checked;
+        const dayCheckboxes = row.querySelectorAll("td:nth-child(4) .days input[type='checkbox']");
+        const days = [...dayCheckboxes].filter(cb => cb.checked).map(cb => parseInt(cb.dataset.index));
+        const autoclose = parseInt(row.querySelector("td:nth-child(5) input").value) || 0;
+        
+        updatedSchedules.push({ enabled, name, url, time, days, autoclose, focus, autodisable });
+    });
+
+    chrome.storage.local.set({ schedules: updatedSchedules }, () => {
+        showSavedMessage();
+    });
+};

--- a/popup.css
+++ b/popup.css
@@ -1,65 +1,241 @@
 body {
     font-family: Arial, sans-serif;
-    width: 200px;  /* Sets a fixed width for the popup */
+    width: 100%;
+    max-width: 330px;
     padding: 15px;
-    background-color: #f8f9fa;
+    background-color: #f9f9f9;
     text-align: center;
-}
+    box-sizing: border-box;
+  }
+  
+  /* Main container spacing with animation */
+  .container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: clamp(1rem, 4vw, 2rem);
+    transition: margin-bottom 0.4s ease;
+  }
+  
+  h1 {
+    color: #007bff;
+    text-align: left;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+  }
+  
+  h2 {
+    text-align: left;
+    font-size: 1.2rem;
+    margin-top: clamp(0.5rem, 2vw, 1rem);
+    margin-bottom: 0.5rem;
+    transition: margin 0.15s ease;
+    opacity: 0;
+    animation: fadeSlideUp 0.2s ease forwards;
+    animation-delay: 0.05s;
+  }
+  
+  label {
+    font-size: 14px;
+    margin-bottom: 5px;
+  }
+  
+  input {
+    font-size: 0.9em;
+    padding: 5px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    width: 100%;
+    margin-top: 4px;
+    margin-bottom: 10px;
+    box-sizing: border-box;
+  }
 
-.container {
+  #interval {
+    width: 80px;
+    max-width: 100%;
+    padding: 6px;
+    font-size: 14px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-bottom: 10px;
+  }
+
+  #toggle-cycle {
+    width: 100%;
+    font-size: 16px;
+    font-weight: bold;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    transition: background-color 0.3s ease;
+    margin-bottom: 1em;
+  }
+  
+  #toggle-cycle.started {
+    background-color: #dc3545; /* Red */
+  }
+  
+  #toggle-cycle.started:hover {
+    background-color: #c82333;
+  }
+  
+  #toggle-cycle.stopped {
+    background-color: #28a745; /* Green */
+  }
+  
+  #toggle-cycle.stopped:hover {
+    background-color: #218838;
+  }
+
+  .button-group {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 1.2rem;
+    transition: margin-bottom 0.4s ease;
+  }
+  
+  button {
+    padding: 0.4em 0.8em;
+    border: none;
+    background: #007acc;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  
+  button:hover {
+    background: #005fa3;
+  }
+  
+  
+  /* Start/Stop Buttons */
+  #start {
+    background-color: #28a745;
+    color: white;
+  }
+  #start:hover {
+    background-color: #218838;
+  }
+  #stop {
+    background-color: #dc3545;
+    color: white;
+  }
+  #stop:hover {
+    background-color: #c82333;
+  }
+  
+  /* Scheduled Table */
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    margin-bottom: 1em;
+    opacity: 0;
+    animation: fadeSlideUp 0.2s ease forwards;
+    animation-delay: 0.1s;
+  }
+  th, td {
+    padding: 8px 10px;
+    text-align: left;
+    border: 1px solid #ddd;
+  }
+  th {
+    background-color: #003366;
+    color: white;
+    font-weight: 600;
+  }
+  tbody tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+  tbody tr:hover {
+    background-color: #e0eaff;
+  }
+  
+  /* Scheduled Entry */
+  .schedule-entry {
+    border: 1px solid #ccc;
+    padding: 8px;
+    margin-bottom: 10px;
+    border-radius: 8px;
+    background: #fff;
+  }
+  .schedule-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  
+  /* Day Buttons */
+  .days {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3em;
+    margin-top: 0.4em;
+  }
+  .days label {
+    background: #eee;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.8em;
+  }
+  
+  /* Popup Buttons */
+  .popup-buttons {
     display: flex;
     flex-direction: column;
     align-items: center;
-}
-
-h3 {
-    color: #007bff;
-    margin-bottom: 10px;
-}
-
-label {
+    margin-top: 1em;
+  }
+  .popup-button {
+    width: 160px;
+    padding: 8px;
+    margin: 5px 0;
     font-size: 14px;
-    margin-bottom: 5px;
-}
-
-input {
-    width: 60px;
-    padding: 5px;
-    font-size: 14px;
-    text-align: center;
-    margin-bottom: 10px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-}
-
-.button-group {
-    display: flex;
-    gap: 10px;
-}
-
-button {
-    padding: 8px 15px;
+    cursor: pointer;
+  }
+  .popup-button.small {
+    width: 16%;
+    font-size: 0.75em;
+    padding: 4px 8px;
+  }
+  .popup-button.large {
+    width: 100%;
+    font-size: 16px;
+    font-weight: bold;
+    color: white;
     border: none;
     border-radius: 4px;
-    cursor: pointer;
-    font-size: 14px;
-    transition: background 0.3s ease;
-}
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    transition: background-color 0.3s ease;
+  }
+  .popup-button.large:hover {
+    background-color: #1d4fa1;
+  }
+  .popup-button.large svg {
+    width: 18px;
+    height: 18px;
+    fill: white;
+  }
 
-#start {
-    background-color: #28a745;
-    color: white;
-}
-
-#start:hover {
-    background-color: #218838;
-}
-
-#stop {
-    background-color: #dc3545;
-    color: white;
-}
-
-#stop:hover {
-    background-color: #c82333;
+@keyframes fadeSlideUp {
+    0% {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }

--- a/popup.html
+++ b/popup.html
@@ -6,16 +6,46 @@
     <title>TabCycle</title>
     <link rel="stylesheet" href="popup.css">
 </head>
+<style>
+    body {
+      width: 500px;
+      max-width: 100%;
+      padding: 10px;
+    }
+</style>
 <body>
     <div class="container">
-        <h3>TabCycle</h3>
-        <label for="interval">Interval (seconds):</label>
+        <h1>TabCycle <span id="version" style="font-size: 0.6em; opacity: 0.7;"></span></h1>
+        <label for="interval">Cycle Interval (in seconds):</label>
         <input id="interval" type="number" min="1" value="15">
         <div class="button-group">
-            <button id="start">Start</button>
-            <button id="stop">Stop</button>
-        </div>
+            <button id="toggle-cycle">
+                <span id="toggle-icon">▶️</span> <span id="toggle-text">Start</span>
+              </button>
+          </div>
     </div>
+
+    <h2 style="display: flex; justify-content: space-between; align-items: center; margin-top: 1em;">
+        Scheduled Tabs
+        <button class="popup-button small" id="preview">Open All</button>
+    </h2>
+  <div id="schedule-list"></div>
+  <table>
+    <thead>
+      <tr>
+        <th>Active</th>
+        <th>Name</th>
+        <th>Date & Time to Open</th>
+        <th>Action</th>
+      </tr>
+    </thead>
+    <tbody id="popup-table-body"></tbody>
+  </table>
+  
+  <div class="popup-buttons">
+    <button class="popup-button large" id="options">Configure Tabs</button>
+  </div>
+
     <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,25 +1,167 @@
-document.getElementById("start").addEventListener("click", () => {
+const scheduleList = document.getElementById("schedule-list");
+const previewButton = document.getElementById("preview");
+const optionsButton = document.getElementById("options");
+const startStopbutton = document.getElementById("toggle-cycle");
+const intervalInput = document.getElementById("interval");
+const icon = document.getElementById("toggle-icon");
+const text = document.getElementById("toggle-text");
+
+let isCycling = false;
+
+function updateToggleButton() {
+  if (isCycling) {
+    startStopbutton.classList.remove("stopped");
+    startStopbutton.classList.add("started");
+    icon.textContent = "⏸️"; // Pause icon
+    text.textContent = "Stop";
+  } else {
+    startStopbutton.classList.remove("started");
+    startStopbutton.classList.add("stopped");
+    icon.textContent = "▶️"; // Play icon
+    text.textContent = "Start";
+  }
+}
+
+document.getElementById("toggle-cycle").addEventListener("click", () => {  
+  if (!isCycling) {
+    // Start tab cycling
     const interval = parseInt(document.getElementById("interval").value, 10) || 5;
     chrome.runtime.sendMessage({ command: "start", interval });
-});
-
-document.getElementById("stop").addEventListener("click", () => {
+  } else {
+    // Stop tab cycling
     chrome.runtime.sendMessage({ command: "stop" });
+  }
+  isCycling = !isCycling;
+  chrome.storage.local.set({ isCycling });
+  updateToggleButton();
 });
 
 document.addEventListener("DOMContentLoaded", () => {
-    let intervalInput = document.getElementById("interval");
+  const versionSpan = document.getElementById("version");
+  const manifest = chrome.runtime.getManifest();
+  versionSpan.textContent = `v${manifest.version}`;
   
-    // Get the stored interval value
-    chrome.storage.local.get("intervalSeconds", (data) => {
-      intervalInput.value = data.intervalSeconds || 5; // Default to 5 if undefined
-    });
-    
-    // Listen for changes and send to background
-    intervalInput.addEventListener("change", () => {
-      let newInterval = parseInt(intervalInput.value, 10);
-      if (!isNaN(newInterval) && newInterval > 0) {
-        chrome.runtime.sendMessage({ action: "setInterval", value: newInterval });
-        }
+  // Get the stored interval value
+  chrome.storage.local.get("intervalSeconds", (data) => {
+    intervalInput.value = data.intervalSeconds || 15; // Default to 5 if undefined
+  });
+  
+  // Listen for changes and send to background
+  intervalInput.addEventListener("input", () => {
+    let newInterval = parseInt(intervalInput.value, 10);
+    if (!isNaN(newInterval) && newInterval > 0) {
+      chrome.runtime.sendMessage({ action: "setInterval", value: newInterval });
+      }
+  });
+  
+  // Stop tab cycling when opening popup
+  chrome.runtime.sendMessage({ command: "stop" });
+  isCycling = false;
+  chrome.storage.local.set({ isCycling });
+  updateToggleButton();
+
+  chrome.storage.local.get("isCycling", (data) => {
+    isCycling = data.isCycling || false;
+    updateToggleButton();
+  });
+  
+  const tableBody = document.createElement("table");
+  tableBody.className = "popup-table";
+
+  const tbody = document.getElementById("popup-table-body");
+  
+  chrome.storage.local.get("schedules", (res) => {
+    const schedules = res.schedules || [];
+
+    schedules.forEach((entry, index) => {
+      const row = document.createElement("tr");
+
+      // Active toggle
+      const activeCell = document.createElement("td");
+      const toggle = document.createElement("input");
+      toggle.type = "checkbox";
+      toggle.checked = entry.enabled;
+      toggle.addEventListener("change", () => {
+        entry.enabled = toggle.checked;
+        saveSchedule(index, entry);
+      });
+      activeCell.appendChild(toggle);
+      row.appendChild(activeCell);
+
+      // Name input
+      const nameCell = document.createElement("td");
+      const nameInput = document.createElement("input");
+      nameInput.type = "text";
+      nameInput.value = entry.name || "";
+      nameInput.addEventListener("change", () => {
+        entry.name = nameInput.value;
+        saveSchedule(index, entry);
+      });
+      nameCell.appendChild(nameInput);
+      row.appendChild(nameCell);
+
+      // Next Open Time
+      const nextOpenCell = document.createElement("td");
+      const nextOpenText = document.createElement("span");
+      let openText = getNextOpenDate(entry) != "Not scheduled" ? `Open on ${getNextOpenDate(entry)}` : `${getNextOpenDate(entry)}`;
+      nextOpenText.innerHTML = `${openText}. Display for <strong>${entry.autoclose} seconds</strong>.`;
+      nextOpenCell.appendChild(nextOpenText);
+      row.appendChild(nextOpenCell);
+
+      // Open Now
+      const openCell = document.createElement("td");
+      const openBtn = document.createElement("button");
+      openBtn.textContent = "Open";
+      openBtn.title = "Open Tab Now";
+      openBtn.addEventListener("click", () => {
+        chrome.tabs.create({ url: entry.url, active: entry.focus || false });
+      });
+      openCell.appendChild(openBtn);
+      row.appendChild(openCell);
+
+      tbody.appendChild(row);
     });
   });
+});
+
+previewButton.onclick = () => {
+  chrome.runtime.sendMessage({ action: "previewNow" });
+};
+
+optionsButton.onclick = () => {
+  chrome.runtime.openOptionsPage();
+};
+
+function saveSchedule(index, updatedEntry) {
+  chrome.storage.local.get("schedules", (res) => {
+    const schedules = res.schedules || [];
+    schedules[index] = updatedEntry;
+    chrome.storage.local.set({ schedules });
+  });
+}
+
+function getNextOpenDate(entry) {
+  if (!entry.days || entry.days.length === 0) return "Not scheduled";
+
+  const now = new Date();
+  const currentDay = now.getDay();
+  const [hour, minute] = entry.time?.split(":").map(Number) || [8, 0];
+
+  for (let i = 0; i <= 7; i++) {
+    const dayToCheck = (currentDay + i) % 7;
+    if (entry.days.includes(dayToCheck)) {
+      const nextDate = new Date(now);
+      nextDate.setDate(now.getDate() + i);
+      nextDate.setHours(hour, minute, 0, 0);
+      if (i === 0 && nextDate < now) continue;
+      const options = { weekday: "long", year: "numeric", month: "long", day: "numeric" };
+      const dateStr = `<strong>${nextDate.toLocaleDateString(undefined, options)}</strong>`;
+      const timeStr = `<strong>${nextDate.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}</strong>`;
+
+      return `${dateStr} at ${timeStr}`;
+
+    }
+  }
+
+  return "No valid date";
+}


### PR DESCRIPTION
### Summary
- Introduced tab scheduling with support for autoclose and autodisable.
- Added a responsive options page for managing scheduled tabs.
- Integrated tab cycling functionality with the new tab scheduling feature.
- Replaced separate Play/Stop buttons with a single toggle.

### How to test
1. Try scheduling a tab and ensure it opens at the correct time.
2. Verify that autoclose removes the tab and resumes cycling.
3. Try toggling cycling using the new Play/Stop button.